### PR TITLE
Configmap version added to ksvc annotations

### DIFF
--- a/pkg/reconciler/function/function.go
+++ b/pkg/reconciler/function/function.go
@@ -208,6 +208,7 @@ func (r *Reconciler) reconcileKnService(ctx context.Context, f *functionv1alpha1
 		resources.KnSvcEnvVar("CE_TYPE", eventType),
 		resources.KnSvcEnvVar("CE_SOURCE", f.SelfLink),
 		resources.KnSvcEnvVar("CE_SUBJECT", handler),
+		resources.KnSvcAnnotation("flow.triggermesh.io/codeVersion", cm.ResourceVersion),
 		resources.KnSvcVisibility(f.Spec.Public),
 		resources.KnSvcLabel(map[string]string{labelKey: f.Name}),
 		resources.KnSvcOwner(f),
@@ -223,8 +224,7 @@ func (r *Reconciler) reconcileKnService(ctx context.Context, f *functionv1alpha1
 	}
 	actualKsvc := ksvcList[0]
 
-	if !reflect.DeepEqual(actualKsvc.Spec.ConfigurationSpec.Template.Spec,
-		expectedKsvc.Spec.ConfigurationSpec.Template.Spec) {
+	if !reflect.DeepEqual(actualKsvc.Spec, expectedKsvc.Spec) {
 		actualKsvc.Spec = expectedKsvc.Spec
 		return r.knServingClientSet.ServingV1().Services(f.Namespace).Update(ctx, actualKsvc, v1.UpdateOptions{})
 	}

--- a/pkg/reconciler/function/resources/knservice.go
+++ b/pkg/reconciler/function/resources/knservice.go
@@ -81,6 +81,15 @@ func KnSvcEnvVar(name, val string) knSvcOption {
 	}
 }
 
+func KnSvcAnnotation(key, value string) knSvcOption {
+	return func(svc *servingv1.Service) {
+		if svc.Spec.Template.Annotations == nil {
+			svc.Spec.Template.Annotations = make(map[string]string)
+		}
+		svc.Spec.Template.Annotations[key] = value
+	}
+}
+
 func KnSvcOwner(o kmeta.OwnerRefable) knSvcOption {
 	return func(svc *servingv1.Service) {
 		svc.SetOwnerReferences([]metav1.OwnerReference{


### PR DESCRIPTION
In this PR Function controller passes ConfigMap's resource version into Kn Service Spec template annotation so that the code is always in sync with the running pods
Closes #6