### PR TITLE
Optional K_SINK support added

### DIFF
--- a/config/300-function.yaml
+++ b/config/300-function.yaml
@@ -60,39 +60,39 @@ spec:
             public:
               description: 'Should the function be publicly available.'
               type: boolean
-            # sink:
-            #   description: 'Sink is a reference to an object that will resolve to
-            #       a uri to use as the sink.'
-            #   type: object
-            #   oneOf:
-            #   - required: ["ref"]
-            #   - required: ["uri"]
-            #   properties:
-            #     ref:
-            #       description: 'Ref points to an Addressable.'
-            #       type: object
-            #       properties:
-            #         apiVersion:
-            #           description: 'API version of the referent.'
-            #           type: string
-            #         kind:
-            #           description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            #           type: string
-            #         name:
-            #           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-            #           type: string
-            #         namespace:
-            #           description: 'Namespace of the referent. More info:
-            #             https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-            #             This is optional field, it gets defaulted to the
-            #             object holding it if left out.'
-            #           type: string
-            #     uri:
-            #       description: 'URI can be an absolute URL(non-empty scheme and
-            #         non-empty host) pointing to the target or a relative URI.
-            #         Relative URIs will be resolved using the base URI retrieved
-            #         from Ref.'
-            #       type: string
+            sink:
+              description: 'Sink is a reference to an object that will resolve to
+                  a uri to use as the sink.'
+              type: object
+              oneOf:
+              - required: ["ref"]
+              - required: ["uri"]
+              properties:
+                ref:
+                  description: 'Ref points to an Addressable.'
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: 'API version of the referent.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info:
+                        https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        This is optional field, it gets defaulted to the
+                        object holding it if left out.'
+                      type: string
+                uri:
+                  description: 'URI can be an absolute URL(non-empty scheme and
+                    non-empty host) pointing to the target or a relative URI.
+                    Relative URIs will be resolved using the base URI retrieved
+                    from Ref.'
+                  type: string
         status:
           type: object
           properties:


### PR DESCRIPTION
Sink support restored in Function CRD. Should be merged after triggermesh/aws-custom-runtime#29 with the new release (v1.4.1) of Knative lambda runtime images.