### PR TITLE
Function CRD moved to "extensions" API group

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -19,7 +19,7 @@ metadata:
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
-      function.flow.triggermesh.io/controller: "true"
+      function.extensions.triggermesh.io/controller: "true"
 rules: [] # Rules are automatically filled in by the controller manager.
 ---
 kind: ClusterRole
@@ -27,7 +27,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: triggermesh-function-core
   labels:
-    function.flow.triggermesh.io/controller: "true"
+    function.extensions.triggermesh.io/controller: "true"
 rules:
   - apiGroups:
     - ""
@@ -78,7 +78,7 @@ rules:
     - patch
     - watch
   - apiGroups:
-    - flow.triggermesh.io
+    - extensions.triggermesh.io
     resources:
     - functions
     - functions/status
@@ -113,7 +113,7 @@ metadata:
     duck.knative.dev/addressable: "true"
 rules:
 - apiGroups:
-  - flow.triggermesh.io
+  - extensions.triggermesh.io
   resources:
   - functions
   - functions/status

--- a/config/300-function.yaml
+++ b/config/300-function.yaml
@@ -15,11 +15,11 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: functions.flow.triggermesh.io
+  name: functions.extensions.triggermesh.io
   labels:
     triggermesh.io/crd-install: "true"
 spec:
-  group: flow.triggermesh.io
+  group: extensions.triggermesh.io
   scope: Namespaced
   names:
     kind: Function
@@ -28,7 +28,7 @@ spec:
     categories:
     - all
     - triggermesh
-    - flow
+    - extensions
     shortNames:
     - fn
   versions: 

--- a/config/samples/nodejs.yaml
+++ b/config/samples/nodejs.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: flow.triggermesh.io/v1alpha1
+apiVersion: extensions.triggermesh.io/v1alpha1
 kind: Function
 metadata:
   name: inline-node-function

--- a/config/samples/python.yaml
+++ b/config/samples/python.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: flow.triggermesh.io/v1alpha1
+apiVersion: extensions.triggermesh.io/v1alpha1
 kind: Function
 metadata:
   name: inline-python-function

--- a/config/samples/ruby.yaml
+++ b/config/samples/ruby.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: flow.triggermesh.io/v1alpha1
+apiVersion: extensions.triggermesh.io/v1alpha1
 kind: Function
 metadata:
   name: inline-ruby-function

--- a/pkg/apis/function/register.go
+++ b/pkg/apis/function/register.go
@@ -17,5 +17,5 @@ limitations under the License.
 package function
 
 const (
-	GroupName = "flow.triggermesh.io"
+	GroupName = "extensions.triggermesh.io"
 )

--- a/pkg/apis/function/v1alpha1/doc.go
+++ b/pkg/apis/function/v1alpha1/doc.go
@@ -15,5 +15,5 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
-// +groupName=flow.triggermesh.io
+// +groupName=extensions.triggermesh.io
 package v1alpha1

--- a/pkg/client/generated/clientset/internalclientset/clientset.go
+++ b/pkg/client/generated/clientset/internalclientset/clientset.go
@@ -21,7 +21,7 @@ package internalclientset
 import (
 	"fmt"
 
-	flowv1alpha1 "github.com/triggermesh/function/pkg/client/generated/clientset/internalclientset/typed/function/v1alpha1"
+	extensionsv1alpha1 "github.com/triggermesh/function/pkg/client/generated/clientset/internalclientset/typed/function/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -29,19 +29,19 @@ import (
 
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
-	FlowV1alpha1() flowv1alpha1.FlowV1alpha1Interface
+	ExtensionsV1alpha1() extensionsv1alpha1.ExtensionsV1alpha1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
 // version included in a Clientset.
 type Clientset struct {
 	*discovery.DiscoveryClient
-	flowV1alpha1 *flowv1alpha1.FlowV1alpha1Client
+	extensionsV1alpha1 *extensionsv1alpha1.ExtensionsV1alpha1Client
 }
 
-// FlowV1alpha1 retrieves the FlowV1alpha1Client
-func (c *Clientset) FlowV1alpha1() flowv1alpha1.FlowV1alpha1Interface {
-	return c.flowV1alpha1
+// ExtensionsV1alpha1 retrieves the ExtensionsV1alpha1Client
+func (c *Clientset) ExtensionsV1alpha1() extensionsv1alpha1.ExtensionsV1alpha1Interface {
+	return c.extensionsV1alpha1
 }
 
 // Discovery retrieves the DiscoveryClient
@@ -65,7 +65,7 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	}
 	var cs Clientset
 	var err error
-	cs.flowV1alpha1, err = flowv1alpha1.NewForConfig(&configShallowCopy)
+	cs.extensionsV1alpha1, err = extensionsv1alpha1.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
 	var cs Clientset
-	cs.flowV1alpha1 = flowv1alpha1.NewForConfigOrDie(c)
+	cs.extensionsV1alpha1 = extensionsv1alpha1.NewForConfigOrDie(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
 	return &cs
@@ -90,7 +90,7 @@ func NewForConfigOrDie(c *rest.Config) *Clientset {
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
 	var cs Clientset
-	cs.flowV1alpha1 = flowv1alpha1.New(c)
+	cs.extensionsV1alpha1 = extensionsv1alpha1.New(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/pkg/client/generated/clientset/internalclientset/fake/clientset_generated.go
+++ b/pkg/client/generated/clientset/internalclientset/fake/clientset_generated.go
@@ -20,8 +20,8 @@ package fake
 
 import (
 	clientset "github.com/triggermesh/function/pkg/client/generated/clientset/internalclientset"
-	flowv1alpha1 "github.com/triggermesh/function/pkg/client/generated/clientset/internalclientset/typed/function/v1alpha1"
-	fakeflowv1alpha1 "github.com/triggermesh/function/pkg/client/generated/clientset/internalclientset/typed/function/v1alpha1/fake"
+	extensionsv1alpha1 "github.com/triggermesh/function/pkg/client/generated/clientset/internalclientset/typed/function/v1alpha1"
+	fakeextensionsv1alpha1 "github.com/triggermesh/function/pkg/client/generated/clientset/internalclientset/typed/function/v1alpha1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
@@ -76,7 +76,7 @@ func (c *Clientset) Tracker() testing.ObjectTracker {
 
 var _ clientset.Interface = &Clientset{}
 
-// FlowV1alpha1 retrieves the FlowV1alpha1Client
-func (c *Clientset) FlowV1alpha1() flowv1alpha1.FlowV1alpha1Interface {
-	return &fakeflowv1alpha1.FakeFlowV1alpha1{Fake: &c.Fake}
+// ExtensionsV1alpha1 retrieves the ExtensionsV1alpha1Client
+func (c *Clientset) ExtensionsV1alpha1() extensionsv1alpha1.ExtensionsV1alpha1Interface {
+	return &fakeextensionsv1alpha1.FakeExtensionsV1alpha1{Fake: &c.Fake}
 }

--- a/pkg/client/generated/clientset/internalclientset/fake/register.go
+++ b/pkg/client/generated/clientset/internalclientset/fake/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	flowv1alpha1 "github.com/triggermesh/function/pkg/apis/function/v1alpha1"
+	extensionsv1alpha1 "github.com/triggermesh/function/pkg/apis/function/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,7 +31,7 @@ var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 
 var localSchemeBuilder = runtime.SchemeBuilder{
-	flowv1alpha1.AddToScheme,
+	extensionsv1alpha1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/pkg/client/generated/clientset/internalclientset/scheme/register.go
+++ b/pkg/client/generated/clientset/internalclientset/scheme/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package scheme
 
 import (
-	flowv1alpha1 "github.com/triggermesh/function/pkg/apis/function/v1alpha1"
+	extensionsv1alpha1 "github.com/triggermesh/function/pkg/apis/function/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,7 +31,7 @@ var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
-	flowv1alpha1.AddToScheme,
+	extensionsv1alpha1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/pkg/client/generated/clientset/internalclientset/typed/function/v1alpha1/fake/fake_function.go
+++ b/pkg/client/generated/clientset/internalclientset/typed/function/v1alpha1/fake/fake_function.go
@@ -32,13 +32,13 @@ import (
 
 // FakeFunctions implements FunctionInterface
 type FakeFunctions struct {
-	Fake *FakeFlowV1alpha1
+	Fake *FakeExtensionsV1alpha1
 	ns   string
 }
 
-var functionsResource = schema.GroupVersionResource{Group: "flow.triggermesh.io", Version: "v1alpha1", Resource: "functions"}
+var functionsResource = schema.GroupVersionResource{Group: "extensions.triggermesh.io", Version: "v1alpha1", Resource: "functions"}
 
-var functionsKind = schema.GroupVersionKind{Group: "flow.triggermesh.io", Version: "v1alpha1", Kind: "Function"}
+var functionsKind = schema.GroupVersionKind{Group: "extensions.triggermesh.io", Version: "v1alpha1", Kind: "Function"}
 
 // Get takes name of the function, and returns the corresponding function object, and an error if there is any.
 func (c *FakeFunctions) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Function, err error) {

--- a/pkg/client/generated/clientset/internalclientset/typed/function/v1alpha1/fake/fake_function_client.go
+++ b/pkg/client/generated/clientset/internalclientset/typed/function/v1alpha1/fake/fake_function_client.go
@@ -24,17 +24,17 @@ import (
 	testing "k8s.io/client-go/testing"
 )
 
-type FakeFlowV1alpha1 struct {
+type FakeExtensionsV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeFlowV1alpha1) Functions(namespace string) v1alpha1.FunctionInterface {
+func (c *FakeExtensionsV1alpha1) Functions(namespace string) v1alpha1.FunctionInterface {
 	return &FakeFunctions{c, namespace}
 }
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeFlowV1alpha1) RESTClient() rest.Interface {
+func (c *FakeExtensionsV1alpha1) RESTClient() rest.Interface {
 	var ret *rest.RESTClient
 	return ret
 }

--- a/pkg/client/generated/clientset/internalclientset/typed/function/v1alpha1/function.go
+++ b/pkg/client/generated/clientset/internalclientset/typed/function/v1alpha1/function.go
@@ -57,7 +57,7 @@ type functions struct {
 }
 
 // newFunctions returns a Functions
-func newFunctions(c *FlowV1alpha1Client, namespace string) *functions {
+func newFunctions(c *ExtensionsV1alpha1Client, namespace string) *functions {
 	return &functions{
 		client: c.RESTClient(),
 		ns:     namespace,

--- a/pkg/client/generated/clientset/internalclientset/typed/function/v1alpha1/function_client.go
+++ b/pkg/client/generated/clientset/internalclientset/typed/function/v1alpha1/function_client.go
@@ -24,22 +24,22 @@ import (
 	rest "k8s.io/client-go/rest"
 )
 
-type FlowV1alpha1Interface interface {
+type ExtensionsV1alpha1Interface interface {
 	RESTClient() rest.Interface
 	FunctionsGetter
 }
 
-// FlowV1alpha1Client is used to interact with features provided by the flow.triggermesh.io group.
-type FlowV1alpha1Client struct {
+// ExtensionsV1alpha1Client is used to interact with features provided by the extensions.triggermesh.io group.
+type ExtensionsV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *FlowV1alpha1Client) Functions(namespace string) FunctionInterface {
+func (c *ExtensionsV1alpha1Client) Functions(namespace string) FunctionInterface {
 	return newFunctions(c, namespace)
 }
 
-// NewForConfig creates a new FlowV1alpha1Client for the given config.
-func NewForConfig(c *rest.Config) (*FlowV1alpha1Client, error) {
+// NewForConfig creates a new ExtensionsV1alpha1Client for the given config.
+func NewForConfig(c *rest.Config) (*ExtensionsV1alpha1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
@@ -48,12 +48,12 @@ func NewForConfig(c *rest.Config) (*FlowV1alpha1Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &FlowV1alpha1Client{client}, nil
+	return &ExtensionsV1alpha1Client{client}, nil
 }
 
-// NewForConfigOrDie creates a new FlowV1alpha1Client for the given config and
+// NewForConfigOrDie creates a new ExtensionsV1alpha1Client for the given config and
 // panics if there is an error in the config.
-func NewForConfigOrDie(c *rest.Config) *FlowV1alpha1Client {
+func NewForConfigOrDie(c *rest.Config) *ExtensionsV1alpha1Client {
 	client, err := NewForConfig(c)
 	if err != nil {
 		panic(err)
@@ -61,9 +61,9 @@ func NewForConfigOrDie(c *rest.Config) *FlowV1alpha1Client {
 	return client
 }
 
-// New creates a new FlowV1alpha1Client for the given RESTClient.
-func New(c rest.Interface) *FlowV1alpha1Client {
-	return &FlowV1alpha1Client{c}
+// New creates a new ExtensionsV1alpha1Client for the given RESTClient.
+func New(c rest.Interface) *ExtensionsV1alpha1Client {
+	return &ExtensionsV1alpha1Client{c}
 }
 
 func setConfigDefaults(config *rest.Config) error {
@@ -81,7 +81,7 @@ func setConfigDefaults(config *rest.Config) error {
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FlowV1alpha1Client) RESTClient() rest.Interface {
+func (c *ExtensionsV1alpha1Client) RESTClient() rest.Interface {
 	if c == nil {
 		return nil
 	}

--- a/pkg/client/generated/informers/externalversions/factory.go
+++ b/pkg/client/generated/informers/externalversions/factory.go
@@ -172,9 +172,9 @@ type SharedInformerFactory interface {
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
-	Flow() function.Interface
+	Extensions() function.Interface
 }
 
-func (f *sharedInformerFactory) Flow() function.Interface {
+func (f *sharedInformerFactory) Extensions() function.Interface {
 	return function.New(f, f.namespace, f.tweakListOptions)
 }

--- a/pkg/client/generated/informers/externalversions/function/v1alpha1/function.go
+++ b/pkg/client/generated/informers/externalversions/function/v1alpha1/function.go
@@ -62,13 +62,13 @@ func NewFilteredFunctionInformer(client internalclientset.Interface, namespace s
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowV1alpha1().Functions(namespace).List(context.TODO(), options)
+				return client.ExtensionsV1alpha1().Functions(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FlowV1alpha1().Functions(namespace).Watch(context.TODO(), options)
+				return client.ExtensionsV1alpha1().Functions(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&functionv1alpha1.Function{},

--- a/pkg/client/generated/informers/externalversions/generic.go
+++ b/pkg/client/generated/informers/externalversions/generic.go
@@ -52,9 +52,9 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=flow.triggermesh.io, Version=v1alpha1
+	// Group=extensions.triggermesh.io, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("functions"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Flow().V1alpha1().Functions().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Extensions().V1alpha1().Functions().Informer()}, nil
 
 	}
 

--- a/pkg/client/generated/injection/informers/function/v1alpha1/function/fake/fake.go
+++ b/pkg/client/generated/injection/informers/function/v1alpha1/function/fake/fake.go
@@ -35,6 +35,6 @@ func init() {
 
 func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 	f := fake.Get(ctx)
-	inf := f.Flow().V1alpha1().Functions()
+	inf := f.Extensions().V1alpha1().Functions()
 	return context.WithValue(ctx, function.Key{}, inf), inf.Informer()
 }

--- a/pkg/client/generated/injection/informers/function/v1alpha1/function/filtered/fake/fake.go
+++ b/pkg/client/generated/injection/informers/function/v1alpha1/function/filtered/fake/fake.go
@@ -44,7 +44,7 @@ func withInformer(ctx context.Context) (context.Context, []controller.Informer) 
 	infs := []controller.Informer{}
 	for _, selector := range labelSelectors {
 		f := factoryfiltered.Get(ctx, selector)
-		inf := f.Flow().V1alpha1().Functions()
+		inf := f.Extensions().V1alpha1().Functions()
 		ctx = context.WithValue(ctx, filtered.Key{Selector: selector}, inf)
 		infs = append(infs, inf.Informer())
 	}

--- a/pkg/client/generated/injection/informers/function/v1alpha1/function/filtered/function.go
+++ b/pkg/client/generated/injection/informers/function/v1alpha1/function/filtered/function.go
@@ -47,7 +47,7 @@ func withInformer(ctx context.Context) (context.Context, []controller.Informer) 
 	infs := []controller.Informer{}
 	for _, selector := range labelSelectors {
 		f := filtered.Get(ctx, selector)
-		inf := f.Flow().V1alpha1().Functions()
+		inf := f.Extensions().V1alpha1().Functions()
 		ctx = context.WithValue(ctx, Key{Selector: selector}, inf)
 		infs = append(infs, inf.Informer())
 	}

--- a/pkg/client/generated/injection/informers/function/v1alpha1/function/function.go
+++ b/pkg/client/generated/injection/informers/function/v1alpha1/function/function.go
@@ -37,7 +37,7 @@ type Key struct{}
 
 func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 	f := factory.Get(ctx)
-	inf := f.Flow().V1alpha1().Functions()
+	inf := f.Extensions().V1alpha1().Functions()
 	return context.WithValue(ctx, Key{}, inf), inf.Informer()
 }
 

--- a/pkg/client/generated/injection/reconciler/function/v1alpha1/function/controller.go
+++ b/pkg/client/generated/injection/reconciler/function/v1alpha1/function/controller.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	defaultControllerAgentName = "function-controller"
-	defaultFinalizerName       = "functions.flow.triggermesh.io"
+	defaultFinalizerName       = "functions.extensions.triggermesh.io"
 )
 
 // NewImpl returns a controller.Impl that handles queuing and feeding work from
@@ -92,7 +92,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 
 	logger = logger.With(
 		zap.String(logkey.ControllerType, ctrTypeName),
-		zap.String(logkey.Kind, "flow.triggermesh.io.Function"),
+		zap.String(logkey.Kind, "extensions.triggermesh.io.Function"),
 	)
 
 	impl := controller.NewImpl(rec, logger, ctrTypeName)

--- a/pkg/client/generated/injection/reconciler/function/v1alpha1/function/reconciler.go
+++ b/pkg/client/generated/injection/reconciler/function/v1alpha1/function/reconciler.go
@@ -313,7 +313,7 @@ func (r *reconcilerImpl) updateStatus(ctx context.Context, existing *v1alpha1.Fu
 		// The first iteration tries to use the injectionInformer's state, subsequent attempts fetch the latest state via API.
 		if attempts > 0 {
 
-			getter := r.Client.FlowV1alpha1().Functions(desired.Namespace)
+			getter := r.Client.ExtensionsV1alpha1().Functions(desired.Namespace)
 
 			existing, err = getter.Get(ctx, desired.Name, metav1.GetOptions{})
 			if err != nil {
@@ -332,7 +332,7 @@ func (r *reconcilerImpl) updateStatus(ctx context.Context, existing *v1alpha1.Fu
 
 		existing.Status = desired.Status
 
-		updater := r.Client.FlowV1alpha1().Functions(existing.Namespace)
+		updater := r.Client.ExtensionsV1alpha1().Functions(existing.Namespace)
 
 		_, err = updater.UpdateStatus(ctx, existing, metav1.UpdateOptions{})
 		return err
@@ -389,7 +389,7 @@ func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource 
 		return resource, err
 	}
 
-	patcher := r.Client.FlowV1alpha1().Functions(resource.Namespace)
+	patcher := r.Client.ExtensionsV1alpha1().Functions(resource.Namespace)
 
 	resourceName := resource.Name
 	updated, err := patcher.Patch(ctx, resourceName, types.MergePatchType, patch, metav1.PatchOptions{})

--- a/pkg/reconciler/function/function.go
+++ b/pkg/reconciler/function/function.go
@@ -216,7 +216,7 @@ func (r *Reconciler) reconcileKnService(ctx context.Context, f *functionv1alpha1
 		resources.KnSvcEnvVar("CE_TYPE", ceAttr.Type),
 		resources.KnSvcEnvVar("CE_SOURCE", ceAttr.Source),
 		resources.KnSvcEnvVar("CE_SUBJECT", ceAttr.Subject),
-		resources.KnSvcAnnotation("flow.triggermesh.io/codeVersion", cm.ResourceVersion),
+		resources.KnSvcAnnotation("extensions.triggermesh.io/codeVersion", cm.ResourceVersion),
 		resources.KnSvcVisibility(f.Spec.Public),
 		resources.KnSvcLabel(map[string]string{labelKey: f.Name}),
 		resources.KnSvcOwner(f),


### PR DESCRIPTION
Function CRD API group changed from `flow` to `extensions` as we agreed in triggermesh/misc#205.
