### PR TITLE
ci: update the prod overlay updates after updating staging overlays

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ workflows:
           name: update-production-config
           cluster: prod
           requires:
-            - publish
+            - update-staging-config
           filters:
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/


### PR DESCRIPTION
we serialize the update to avoid race conditions when the config update is updated by two jobs at the same time