### PR TITLE
Kustomization base added

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -92,17 +92,6 @@ rules:
     - patch
     - watch
 ---
-# Use this aggregated ClusterRole when you need readonly access to "Addressables"
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: addressable-resolver
-aggregationRule:
-  clusterRoleSelectors:
-  - matchLabels:
-      duck.knative.dev/addressable: "true"
-rules: [] # Rules are automatically filled in by the controller manager.
----
 # The role is needed for the aggregated role addressable-resolver in knative-eventing to provide readonly access to "Addressables".
 # see https://github.com/knative/eventing/blob/release-0.16/docs/spec/channel.md#aggregated-addressable-resolver-clusterrole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/200-resolver-clusterrole.yaml
+++ b/config/200-resolver-clusterrole.yaml
@@ -1,0 +1,24 @@
+# Copyright 2021 Triggermesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use this aggregated ClusterRole when you need readonly access to "Addressables"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: addressable-resolver
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      duck.knative.dev/addressable: "true"
+rules: [] # Rules are automatically filled in by the controller manager.

--- a/config/200-user-clusterrole.yaml
+++ b/config/200-user-clusterrole.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 Triggermesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: triggermesh-extensions-user
+  labels:
+    rbac.triggermesh.io/extensions-user: "true"
+rules:
+  - apiGroups:
+    - extensions.triggermesh.io
+    resources:
+    - functions
+    verbs: 
+    - get
+    - list
+    - create
+    - update
+    - patch
+    - delete

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- config/200-clusterrole.yaml
+- config/200-user-clusterrole.yaml
+- config/200-serviceaccount.yaml
+- config/201-clusterrolebinding.yaml
+- config/300-function.yaml
+- config/controller.yaml


### PR DESCRIPTION
As a part of deployment optimization described in [here](https://github.com/triggermesh/config/issues/516), this repository should act as a remote base for Kustomization. `kustomization.yaml` with deployment resources added to the repository root to keep `config` directory ko apply-able.