### PR TITLE
Function Response Mode and empty overrides support added

### DIFF
--- a/config/300-function.yaml
+++ b/config/300-function.yaml
@@ -60,6 +60,9 @@ spec:
             public:
               description: 'Should the function be publicly available.'
               type: boolean
+            responseMode:
+              description: 'Whether function responds with CE payload only or with full event.'
+              type: string
             ceOverrides:
               type: object
               description: "Defines overrides to control modifications of the event attributes."

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -56,8 +56,8 @@ spec:
           value: triggermesh.io/routing
 
         - name: RUNTIME_KLR_PYTHON
-          value: gcr.io/triggermesh/knative-lambda-python37:v1.5.1
+          value: gcr.io/triggermesh/knative-lambda-python37:v1.8.1
         - name: RUNTIME_KLR_NODE
-          value: gcr.io/triggermesh/knative-lambda-node10:v1.5.1
+          value: gcr.io/triggermesh/knative-lambda-node10:v1.8.1
         - name: RUNTIME_KLR_RUBY
-          value: gcr.io/triggermesh/knative-lambda-ruby25:v1.5.1
+          value: gcr.io/triggermesh/knative-lambda-ruby25:v1.8.1

--- a/config/samples/python.yaml
+++ b/config/samples/python.yaml
@@ -18,21 +18,33 @@ metadata:
   name: inline-python-function
 spec:
   runtime: python
+  responseMode: event
   public: true
   ceOverrides:
     extensions:
       type: io.triggermesh.python.sample
-  entrypoint: foo
+  entrypoint: endpoint
   code: |
-    import urllib.request
+    from random import randrange
 
-    def foo(event, context):
-      resp = urllib.request.urlopen(event['url'])
-      page = resp.read()
+    def endpoint(event, context):
+      val = randrange(10)
+      if (val % 2) == 0:
+        result = {
+          "type" : "io.triggermesh.klr.even",
+          "datacontenttype" : "application/json",
+          "data" : {
+            "value" : val
+          }
+        }
 
-      response = {
-        "statusCode": resp.status,
-        "body": str(page)
-      }
+      else:
+        result = {
+          "type" : "io.triggermesh.klr.odd",
+          "datacontenttype" : "application/json",
+          "data" : {
+            "value" : val
+          }
+        }
+      return result
 
-      return response

--- a/pkg/apis/function/v1alpha1/function_types.go
+++ b/pkg/apis/function/v1alpha1/function_types.go
@@ -55,6 +55,7 @@ type FunctionSpec struct {
 	Entrypoint          string                      `json:"entrypoint"`
 	Public              bool                        `json:"public,omitempty"`
 	Code                string                      `json:"code"`
+	ResponseMode        string                      `json:"responseMode,omitempty"`
 	CloudEventOverrides *duckv1.CloudEventOverrides `json:"ceOverrides"`
 	Sink                *duckv1.Destination         `json:"sink"`
 }

--- a/pkg/reconciler/function/resources/knservice.go
+++ b/pkg/reconciler/function/resources/knservice.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"path"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -182,4 +183,16 @@ func firstContainer(svc *servingv1.Service) *corev1.Container {
 		*containers = make([]corev1.Container, 1)
 	}
 	return &(*containers)[0]
+}
+
+func KnSvcEnvFromMap(prefix string, vars map[string]string) knSvcOption {
+	return func(svc *servingv1.Service) {
+		svcEnvVars := envVarsFrom(svc)
+		for k, v := range vars {
+			*svcEnvVars = append(*svcEnvVars, corev1.EnvVar{
+				Name:  strings.ToUpper(prefix + k),
+				Value: v,
+			})
+		}
+	}
 }


### PR DESCRIPTION
Function's `responseMode` new parameter identifies the type of data returned from the function:
- `data` - function responds with CE data that should be wrapped into CE context,  
- `event` - function responds with CE event in binary format.

Consequently, `ceOverrides` can be empty if the function is responding with the full event, including new context. If `ceOverrides` are set, they are used as default values. Otherwise, if `ceOverrides` are not set and the function is not providing required attributes, default values are set by the controller and KLR runtimes.
Python sample updated to demonstrate "event" response mode.
