### PR TITLE
Sink availability check and adapter semantic matching added

### DIFF
--- a/pkg/apis/function/v1alpha1/function_lifecycle.go
+++ b/pkg/apis/function/v1alpha1/function_lifecycle.go
@@ -65,7 +65,7 @@ func (fs *FunctionStatus) MarkServiceAvailable() {
 }
 
 // MarkSinkUnavailable updates Function status with Sink Not Ready condition
-func (fs *FunctionStatus) MarkSinkUnavailable(name string) {
+func (fs *FunctionStatus) MarkSinkUnavailable() {
 	condSet.Manage(fs).MarkFalse(
 		ConditionSinkReady,
 		"SinkUnavailable",

--- a/pkg/reconciler/function/function.go
+++ b/pkg/reconciler/function/function.go
@@ -102,8 +102,17 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *functionv1alpha1.Func
 	}
 	o.Status.MarkConfigmapAvailable()
 
+	sink, err := r.resolveSink(ctx, o)
+	if err != nil {
+		logger.Error("Error resolving sink", zap.Error(err))
+		o.Status.MarkSinkUnavailable()
+		return err
+	}
+	o.Status.SinkURI = sink
+	o.Status.MarkSinkAvailable()
+
 	// Reconcile Transformation Adapter
-	ksvc, err := r.reconcileKnService(ctx, o, cm)
+	ksvc, err := r.reconcileKnService(ctx, o, cm, sink)
 	if err != nil {
 		logger.Error("Error reconciling Kn Service", zap.Error(err))
 		o.Status.MarkServiceUnavailable(o.Name)
@@ -139,10 +148,21 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *functionv1alpha1.Func
 		o.Status.CloudEventAttributes = r.statusAttributes(o.Spec.CloudEventOverrides.Extensions)
 	}
 
-	o.Status.MarkSinkAvailable()
-
 	logger.Debug("Transformation reconciled")
 	return newReconciledNormal(o.Namespace, o.Name)
+}
+
+func (r *Reconciler) resolveSink(ctx context.Context, f *functionv1alpha1.Function) (*apis.URL, error) {
+	if f.Spec.Sink != nil {
+		dest := f.Spec.Sink.DeepCopy()
+		if dest.Ref != nil {
+			if dest.Ref.Namespace == "" {
+				dest.Ref.Namespace = f.GetNamespace()
+			}
+		}
+		return r.sinkResolver.URIFromDestinationV1(ctx, *dest, f)
+	}
+	return &apis.URL{}, nil
 }
 
 func (r *Reconciler) reconcileConfigmap(ctx context.Context, f *functionv1alpha1.Function) (*corev1.ConfigMap, error) {
@@ -174,30 +194,12 @@ func (r *Reconciler) reconcileConfigmap(ctx context.Context, f *functionv1alpha1
 	return actualCm, nil
 }
 
-func (r *Reconciler) reconcileKnService(ctx context.Context, f *functionv1alpha1.Function, cm *corev1.ConfigMap) (*servingv1.Service, error) {
+func (r *Reconciler) reconcileKnService(ctx context.Context, f *functionv1alpha1.Function, cm *corev1.ConfigMap, sink *apis.URL) (*servingv1.Service, error) {
 	logger := logging.FromContext(ctx)
 
 	image, err := r.lookupRuntimeImage(f.Spec.Runtime)
 	if err != nil {
 		return nil, err
-	}
-
-	var sink string
-	if f.Spec.Sink != nil {
-		dest := f.Spec.Sink.DeepCopy()
-		if dest.Ref != nil {
-			if dest.Ref.Namespace == "" {
-				dest.Ref.Namespace = f.GetNamespace()
-			}
-		}
-
-		uri, err := r.sinkResolver.URIFromDestinationV1(ctx, *dest, f)
-		if err != nil {
-			logger.Infof("Sink resolution error: %v", err)
-		} else {
-			f.Status.SinkURI = uri
-			sink = uri.String()
-		}
 	}
 
 	filename := fmt.Sprintf("source.%s", fileExtension(f.Spec.Runtime))
@@ -219,7 +221,7 @@ func (r *Reconciler) reconcileKnService(ctx context.Context, f *functionv1alpha1
 		resources.KnSvcImage(image),
 		resources.KnSvcMountCm(cm.Name, filename),
 		resources.KnSvcEntrypoint(klrEntrypoint),
-		resources.KnSvcEnvVar("K_SINK", sink),
+		resources.KnSvcEnvVar("K_SINK", sink.String()),
 		resources.KnSvcEnvVar("_HANDLER", handler),
 		resources.KnSvcEnvVar("RESPONSE_FORMAT", "CLOUDEVENTS"),
 		resources.KnSvcEnvVar("CE_FUNCTION_RESPONSE_MODE", f.Spec.ResponseMode),

--- a/pkg/reconciler/function/resources/knservice.go
+++ b/pkg/reconciler/function/resources/knservice.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -116,6 +116,7 @@ func KnSvcMountCm(cmSrc, fileDst string) knSvcOption {
 		svc.Spec.ConfigurationSpec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
 			{
 				Name:      "user-function",
+				ReadOnly:  true,
 				MountPath: path.Join(MountPath, fileDst),
 				SubPath:   fileDst,
 			},

--- a/pkg/reconciler/function/semantic/semantic.go
+++ b/pkg/reconciler/function/semantic/semantic.go
@@ -1,0 +1,109 @@
+/*
+Copyright (c) 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package semantic
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
+)
+
+// Semantic can do semantic deep equality checks for Kubernetes API objects.
+//
+// For a given comparison function
+//
+//   comp(a, b interface{})
+//
+// 'a' should always be the desired state, and 'b' the current state for
+// DeepDerivative comparisons to work as expected.
+var Semantic = conversion.EqualitiesOrDie(
+	knServiceEqual,
+)
+
+// eq is an instance of Equalities for internal deep derivative comparisons
+// of API objects. Adapted from "k8s.io/apimachinery/pkg/api/equality".Semantic.
+var eq = conversion.EqualitiesOrDie(
+	func(a, b resource.Quantity) bool {
+		if a.IsZero() {
+			return true
+		}
+		return a.Cmp(b) == 0
+	},
+	func(a, b metav1.Time) bool { // e.g. metadata.creationTimestamp
+		if a.IsZero() {
+			return true
+		}
+		return a.UTC() == b.UTC()
+	},
+	func(a, b int64) bool { // e.g. metadata.generation
+		if a == 0 {
+			return true
+		}
+		return a == b
+	},
+	// Needed because DeepDerivative compares int values directly, which
+	// doesn't yield the expected result with defaulted int32 probe fields.
+	func(a, b *corev1.Probe) bool {
+		if a == nil {
+			return true
+		}
+		if b == nil {
+			return false
+		}
+
+		if a.InitialDelaySeconds != 0 && a.InitialDelaySeconds != b.InitialDelaySeconds {
+			return false
+		}
+		if a.TimeoutSeconds != 0 && a.TimeoutSeconds != b.TimeoutSeconds {
+			return false
+		}
+		if a.PeriodSeconds != 0 && a.PeriodSeconds != b.PeriodSeconds {
+			return false
+		}
+		if a.SuccessThreshold != 0 && a.SuccessThreshold != b.SuccessThreshold {
+			return false
+		}
+		if a.FailureThreshold != 0 && a.FailureThreshold != b.FailureThreshold {
+			return false
+		}
+
+		return (conversion.Equalities{}).DeepDerivative(a.Handler, b.Handler)
+	},
+)
+
+// knServiceEqual returns whether two Knative Services are semantically equivalent.
+func knServiceEqual(a, b *servingv1.Service) bool {
+	if a == b {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+
+	if !eq.DeepDerivative(&a.ObjectMeta, &b.ObjectMeta) {
+		return false
+	}
+
+	if !eq.DeepDerivative(&a.Spec.Template, &b.Spec.Template) {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
This PR should resolve #28 by setting Function's readiness status into `SinkUnavailable` if sink address cannot be resolved.
Also, it partially fixes  #29 by introducing `semantic` package for adapter ksvc matching needs.