### PR TITLE
User clusterrole update

### DIFF
--- a/config/200-user-clusterrole.yaml
+++ b/config/200-user-clusterrole.yaml
@@ -26,6 +26,7 @@ rules:
     verbs: 
     - get
     - list
+    - watch
     - create
     - update
     - patch


### PR DESCRIPTION
So that finally Triggerflow could watch all user functions. Follow-up Triggerflow aggregation update coming.